### PR TITLE
Add pull-to-refresh, swipeable cards, and enhanced event share dialogs to RacesPage

### DIFF
--- a/frontend/components/RaceFinishCard.tsx
+++ b/frontend/components/RaceFinishCard.tsx
@@ -25,6 +25,8 @@ interface RaceFinishCardProps {
     distanceLabel: string | null;
     date: string | null;
     activityType?: string;
+    open?: boolean;
+    onClose?: () => void;
 }
 
 const CARD_WIDTH = 1080;
@@ -228,12 +230,14 @@ function renderFinishCard(
 }
 
 export default function RaceFinishCard(props: RaceFinishCardProps) {
-    const { eventName, raceName, distanceLabel, date, activityType } = props;
+    const { eventName, raceName, distanceLabel, date, activityType, open: openProp, onClose: onCloseProp } = props;
     const { t } = useTranslation();
     const theme = useTheme();
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const [brandImage, setBrandImage] = useState<HTMLImageElement | null>(null);
-    const [open, setOpen] = useState(false);
+    const [openInternal, setOpenInternal] = useState(false);
+    const open = openProp !== undefined ? openProp : openInternal;
+    const handleClose = () => { onCloseProp ? onCloseProp() : setOpenInternal(false); };
     const [finishTime, setFinishTime] = useState('');
     const [rendered, setRendered] = useState(false);
     const [snackbar, setSnackbar] = useState('');
@@ -310,25 +314,27 @@ export default function RaceFinishCard(props: RaceFinishCardProps) {
 
     return (
         <>
-            <Button
-                variant="contained"
-                color="success"
-                startIcon={<EmojiEventsIcon />}
-                onClick={() => setOpen(true)}
-                sx={{ textTransform: 'none' }}
-            >
-                {t('races.finishCard.button', { defaultValue: 'I finished! 🏁' })}
-            </Button>
+            {openProp === undefined && (
+                <Button
+                    variant="contained"
+                    color="success"
+                    startIcon={<EmojiEventsIcon />}
+                    onClick={() => setOpenInternal(true)}
+                    sx={{ textTransform: 'none' }}
+                >
+                    {t('races.finishCard.button', { defaultValue: 'I finished! 🏁' })}
+                </Button>
+            )}
 
             <Dialog
                 open={open}
-                onClose={() => setOpen(false)}
+                onClose={handleClose}
                 maxWidth="sm"
                 fullWidth
             >
                 <IconButton
                     aria-label="close"
-                    onClick={() => setOpen(false)}
+                    onClick={handleClose}
                     sx={{ position: 'absolute', right: 8, top: 8, zIndex: 1 }}
                 >
                     <CloseIcon />

--- a/frontend/components/RaceShareCard.tsx
+++ b/frontend/components/RaceShareCard.tsx
@@ -21,6 +21,8 @@ interface RaceShareCardProps {
     date: string | null;
     daysUntil: number | null;
     activityType?: string;
+    open?: boolean;
+    onClose?: () => void;
 }
 
 const CARD_WIDTH = 1080;
@@ -211,12 +213,15 @@ function wrapText(ctx: CanvasRenderingContext2D, text: string, maxWidth: number)
 }
 
 export default function RaceShareCard(props: RaceShareCardProps) {
-    const { eventName, raceName, distanceLabel, date, daysUntil, activityType } = props;
+    const { eventName, raceName, distanceLabel, date, daysUntil, activityType, open: openProp, onClose: onCloseProp } = props;
     const { t } = useTranslation();
     const theme = useTheme();
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const [brandImage, setBrandImage] = useState<HTMLImageElement | null>(null);
-    const [open, setOpen] = useState(false);
+    const [openInternal, setOpenInternal] = useState(false);
+    const open = openProp !== undefined ? openProp : openInternal;
+    const setOpen = openProp !== undefined ? () => {} : setOpenInternal;
+    const handleClose = () => { onCloseProp ? onCloseProp() : setOpenInternal(false); };
     const [rendered, setRendered] = useState(false);
     const [snackbar, setSnackbar] = useState('');
     const isDark = theme.palette.mode === 'dark';
@@ -291,25 +296,27 @@ export default function RaceShareCard(props: RaceShareCardProps) {
 
     return (
         <>
-            <Button
-                variant="contained"
-                color="secondary"
-                startIcon={<ShareIcon />}
-                onClick={() => setOpen(true)}
-                sx={{ textTransform: 'none' }}
-            >
-                {t('races.shareCard.button', { defaultValue: "I'm racing! 💥" })}
-            </Button>
+            {openProp === undefined && (
+                <Button
+                    variant="contained"
+                    color="secondary"
+                    startIcon={<ShareIcon />}
+                    onClick={() => setOpenInternal(true)}
+                    sx={{ textTransform: 'none' }}
+                >
+                    {t('races.shareCard.button', { defaultValue: "I'm racing! 💥" })}
+                </Button>
+            )}
 
             <Dialog
                 open={open}
-                onClose={() => setOpen(false)}
+                onClose={handleClose}
                 maxWidth="sm"
                 fullWidth
             >
                 <IconButton
                     aria-label="close"
-                    onClick={() => setOpen(false)}
+                    onClick={handleClose}
                     sx={{ position: 'absolute', right: 8, top: 8, zIndex: 1 }}
                 >
                     <CloseIcon />

--- a/frontend/components/SwipeableCard.tsx
+++ b/frontend/components/SwipeableCard.tsx
@@ -1,0 +1,140 @@
+import { useRef, useState } from 'react';
+import { Box } from '@mui/material';
+
+interface SwipeableCardProps {
+    children: React.ReactNode;
+    leftActions?: React.ReactNode;
+    revealWidth?: number;
+    onSwipeRight?: () => void;
+    disabled?: boolean;
+}
+
+const LEFT_THRESHOLD = 60;
+const RIGHT_THRESHOLD = 60;
+
+export default function SwipeableCard({
+    children,
+    leftActions,
+    revealWidth = 130,
+    onSwipeRight,
+    disabled = false,
+}: SwipeableCardProps) {
+    const [offsetX, setOffsetX] = useState(0);
+    const [animating, setAnimating] = useState(false);
+    const [revealed, setRevealed] = useState(false);
+
+    const touchStartX = useRef<number | null>(null);
+    const touchStartY = useRef<number | null>(null);
+    const isScrolling = useRef<boolean | null>(null);
+
+    const snapTo = (x: number, isRevealed: boolean) => {
+        setAnimating(true);
+        setOffsetX(x);
+        setRevealed(isRevealed);
+    };
+
+    const handleTouchStart = (e: React.TouchEvent) => {
+        if (disabled) return;
+        touchStartX.current = e.touches[0].clientX;
+        touchStartY.current = e.touches[0].clientY;
+        isScrolling.current = null;
+        setAnimating(false);
+    };
+
+    const handleTouchMove = (e: React.TouchEvent) => {
+        if (disabled || touchStartX.current === null || touchStartY.current === null) return;
+
+        const deltaX = e.touches[0].clientX - touchStartX.current;
+        const deltaY = e.touches[0].clientY - touchStartY.current;
+
+        if (isScrolling.current === null) {
+            if (Math.abs(deltaY) > Math.abs(deltaX) + 5) {
+                isScrolling.current = true;
+            } else if (Math.abs(deltaX) > 10) {
+                isScrolling.current = false;
+            }
+        }
+
+        if (isScrolling.current) return;
+
+        if (revealed) {
+            const newOffset = Math.min(0, -revealWidth + Math.max(0, deltaX));
+            setOffsetX(newOffset);
+        } else if (deltaX < 0 && leftActions) {
+            setOffsetX(Math.max(-revealWidth, deltaX));
+        } else if (deltaX > 0 && onSwipeRight) {
+            setOffsetX(Math.min(80, deltaX * 0.4));
+        }
+    };
+
+    const handleTouchEnd = (e: React.TouchEvent) => {
+        if (disabled || touchStartX.current === null) return;
+
+        const deltaX = e.changedTouches[0].clientX - touchStartX.current;
+        const wasScrolling = isScrolling.current;
+
+        touchStartX.current = null;
+        touchStartY.current = null;
+        isScrolling.current = null;
+
+        if (wasScrolling) return;
+
+        if (revealed) {
+            if (deltaX > LEFT_THRESHOLD) {
+                snapTo(0, false);
+            } else {
+                snapTo(-revealWidth, true);
+            }
+            return;
+        }
+
+        if (deltaX < -LEFT_THRESHOLD && leftActions) {
+            snapTo(-revealWidth, true);
+        } else if (deltaX > RIGHT_THRESHOLD && onSwipeRight) {
+            snapTo(0, false);
+            onSwipeRight();
+        } else {
+            snapTo(0, false);
+        }
+    };
+
+    const closeReveal = () => {
+        if (revealed) snapTo(0, false);
+    };
+
+    return (
+        <Box sx={{ position: 'relative', overflow: 'hidden', borderRadius: 'inherit' }}>
+            {/* Left-swipe action panel — sits behind the card on the right */}
+            {leftActions && (
+                <Box sx={{
+                    position: 'absolute',
+                    right: 0,
+                    top: 0,
+                    bottom: 0,
+                    width: revealWidth,
+                    display: 'flex',
+                    alignItems: 'stretch',
+                }}>
+                    {leftActions}
+                </Box>
+            )}
+
+            {/* Card — slides with touch */}
+            <Box
+                onTouchStart={handleTouchStart}
+                onTouchMove={handleTouchMove}
+                onTouchEnd={handleTouchEnd}
+                onClick={revealed ? closeReveal : undefined}
+                sx={{
+                    transform: `translateX(${offsetX}px)`,
+                    transition: animating ? 'transform 0.25s ease' : 'none',
+                    position: 'relative',
+                    zIndex: 1,
+                    cursor: revealed ? 'pointer' : undefined,
+                }}
+            >
+                {children}
+            </Box>
+        </Box>
+    );
+}

--- a/frontend/hooks/useEvents.ts
+++ b/frontend/hooks/useEvents.ts
@@ -97,7 +97,7 @@ export interface EventDetail extends EventSummary {
 }
 
 export function useEvents() {
-    const { data: events = [], isPending, error: queryError } = useQuery<EventSummary[]>({
+    const { data: events = [], isPending, error: queryError, refetch } = useQuery<EventSummary[]>({
         queryKey: ['events'],
         queryFn: () => fetch(`${API_URL}/api/v1/events`)
             .then(res => {
@@ -106,7 +106,7 @@ export function useEvents() {
             }),
         staleTime: 5 * 60 * 1000,
     });
-    return { events, loading: isPending, error: queryError instanceof Error ? queryError.message : null };
+    return { events, loading: isPending, error: queryError instanceof Error ? queryError.message : null, refresh: refetch };
 }
 
 export function useEventBySlug(slug: string | undefined) {

--- a/frontend/pages/RacesPage.tsx
+++ b/frontend/pages/RacesPage.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useMemo, useState } from 'react';
+import { lazy, Suspense, useMemo, useState, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
     Container,
@@ -27,6 +27,7 @@ import {
     Checkbox,
     Divider,
     Autocomplete,
+    Fade,
 } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import SearchIcon from '@mui/icons-material/Search';
@@ -39,6 +40,9 @@ import MapIcon from '@mui/icons-material/Map';
 import TableChartIcon from '@mui/icons-material/TableChart';
 import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import FilterListIcon from '@mui/icons-material/FilterList';
+import ShareIcon from '@mui/icons-material/Share';
+import EventAvailableIcon from '@mui/icons-material/EventAvailable';
+import RefreshIcon from '@mui/icons-material/Refresh';
 import DirectionsRunIcon from '@mui/icons-material/DirectionsRun';
 import HikingIcon from '@mui/icons-material/Hiking';
 import DirectionsBikeIcon from '@mui/icons-material/DirectionsBike';
@@ -50,8 +54,12 @@ import Layout from '../components/Layout';
 import RandomQuote from '../components/RandomQuote';
 import RunningLoader from '../components/RunningLoader';
 import EventDateBadge from '../components/EventDateBadge';
+import SwipeableCard from '../components/SwipeableCard';
+import RaceShareCard from '../components/RaceShareCard';
+import RaceFinishCard from '../components/RaceFinishCard';
 import VideocamIcon from '@mui/icons-material/Videocam';
 import { useEvents, type EventSummary } from '../hooks/useEvents';
+import { downloadIcs } from '../utils/calendarLinks';
 import { useFeatureFlags } from '../hooks/useFeatureFlags';
 import { toUserFriendlyFetchError } from '../utils/apiErrors';
 import { getTicketStatusColor, groupDistances } from '../utils/ticketStatus';
@@ -129,7 +137,7 @@ const ACTIVITY_ICONS: Record<string, React.ReactNode> = {
 
 export default function RacesPage({ mode, onToggleMode, showQuote = false }: RacesPageProps) {
     const { t } = useTranslation();
-    const { events, loading, error } = useEvents();
+    const { events, loading, error, refresh } = useEvents();
     const { isEnabled } = useFeatureFlags();
     const locationsEnabled = isEnabled('locations_page');
     const navigate = useNavigate();
@@ -137,6 +145,30 @@ export default function RacesPage({ mode, onToggleMode, showQuote = false }: Rac
     const [search, setSearch] = useState('');
     const [showFilters, setShowFilters] = useState(false);
     const [filters, setFilters] = useState<EventFilters>(DEFAULT_FILTERS);
+    const [shareEventId, setShareEventId] = useState<string | null>(null);
+    const [pullOffset, setPullOffset] = useState(0);
+    const [refreshing, setRefreshing] = useState(false);
+    const touchStartY = useRef<number | null>(null);
+    const PULL_THRESHOLD = 80;
+
+    const handlePullStart = (e: React.TouchEvent) => {
+        if (window.scrollY === 0) touchStartY.current = e.touches[0].clientY;
+    };
+    const handlePullMove = (e: React.TouchEvent) => {
+        if (touchStartY.current === null || refreshing) return;
+        const delta = e.touches[0].clientY - touchStartY.current;
+        if (delta > 0) setPullOffset(Math.min(delta * 0.4, PULL_THRESHOLD + 20));
+    };
+    const handlePullEnd = async () => {
+        if (pullOffset >= PULL_THRESHOLD) {
+            setRefreshing(true);
+            await refresh();
+            setRefreshing(false);
+        }
+        setPullOffset(0);
+        touchStartY.current = null;
+    };
+
     const [viewMode, setViewMode] = useState<ViewMode>(() => {
         try {
             const saved = localStorage.getItem('utanvega-events-view-mode');
@@ -265,7 +297,30 @@ export default function RacesPage({ mode, onToggleMode, showQuote = false }: Rac
     return (
         <Layout mode={mode} onToggleMode={onToggleMode} maxWidth={viewMode === 'table' ? 'lg' : 'md'}>
             {showQuote && isEnabled('random_quote') && <RandomQuote />}
-            <Container maxWidth={viewMode === 'table' ? 'lg' : 'md'} sx={{ py: 3 }}>
+            <Container
+                maxWidth={viewMode === 'table' ? 'lg' : 'md'}
+                sx={{ py: 3 }}
+                onTouchStart={handlePullStart}
+                onTouchMove={handlePullMove}
+                onTouchEnd={handlePullEnd}
+            >
+                {/* Pull-to-refresh indicator */}
+                <Fade in={pullOffset > 10}>
+                    <Box sx={{ display: 'flex', justifyContent: 'center', mb: 1, height: 32, alignItems: 'center' }}>
+                        {refreshing ? (
+                            <CircularProgress size={24} />
+                        ) : (
+                            <RefreshIcon
+                                sx={{
+                                    fontSize: 28,
+                                    color: pullOffset >= PULL_THRESHOLD ? 'primary.main' : 'text.disabled',
+                                    transform: `rotate(${(pullOffset / PULL_THRESHOLD) * 360}deg)`,
+                                    transition: 'color 0.2s',
+                                }}
+                            />
+                        )}
+                    </Box>
+                </Fade>
                 {/* Header */}
                 <Box sx={{ mb: 3 }}>
                     <Stack direction="row" alignItems="center" justifyContent="space-between" flexWrap="wrap" gap={1}>
@@ -605,8 +660,12 @@ export default function RacesPage({ mode, onToggleMode, showQuote = false }: Rac
                                     </Typography>
                                     <Stack spacing={1.5}>
                                         {justRaced.map(comp => (
-                                            <Card
+                                            <SwipeableCard
                                                 key={comp.id}
+                                                onSwipeRight={() => setShareEventId(comp.id)}
+                                                revealWidth={0}
+                                            >
+                                            <Card
                                                 sx={{
                                                     transition: 'transform 0.15s, box-shadow 0.15s',
                                                     '&:hover': { transform: 'translateY(-2px)', boxShadow: theme.shadows[4] },
@@ -658,14 +717,82 @@ export default function RacesPage({ mode, onToggleMode, showQuote = false }: Rac
                                                     </CardContent>
                                                 </CardActionArea>
                                             </Card>
+                                            </SwipeableCard>
                                         ))}
                                     </Stack>
                                 </Box>
                             )}
                         <Stack spacing={2}>
                             {upcoming.map(comp => (
-                                <Card
+                                <SwipeableCard
                                     key={comp.id}
+                                    onSwipeRight={comp.status !== 'Cancelled' && comp.daysUntil != null && comp.daysUntil >= 0
+                                        ? () => setShareEventId(comp.id)
+                                        : undefined
+                                    }
+                                    leftActions={
+                                        <Box sx={{ display: 'flex', flexDirection: 'column', width: '100%' }}>
+                                            {comp.registrationUrl && comp.daysUntil != null && comp.daysUntil >= 0 && (
+                                                <Box
+                                                    component="a"
+                                                    href={comp.registrationUrl}
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                                                    sx={{
+                                                        flex: 1,
+                                                        display: 'flex',
+                                                        flexDirection: 'column',
+                                                        alignItems: 'center',
+                                                        justifyContent: 'center',
+                                                        bgcolor: 'success.main',
+                                                        color: 'white',
+                                                        textDecoration: 'none',
+                                                        gap: 0.5,
+                                                        px: 1,
+                                                        fontSize: '0.7rem',
+                                                        fontWeight: 600,
+                                                    }}
+                                                >
+                                                    <OpenInNewIcon sx={{ fontSize: 18 }} />
+                                                    {t('races.register', 'Register')}
+                                                </Box>
+                                            )}
+                                            {(comp.displayDate ?? comp.nextEditionDate) && (
+                                                <Box
+                                                    onClick={(e: React.MouseEvent) => {
+                                                        e.stopPropagation();
+                                                        downloadIcs({
+                                                            title: comp.name,
+                                                            date: (comp.displayDate ?? comp.nextEditionDate)!,
+                                                            location: comp.locationName ?? undefined,
+                                                            url: `https://hlaupadagskra.is/events/${comp.slug}`,
+                                                        });
+                                                    }}
+                                                    sx={{
+                                                        flex: 1,
+                                                        display: 'flex',
+                                                        flexDirection: 'column',
+                                                        alignItems: 'center',
+                                                        justifyContent: 'center',
+                                                        bgcolor: 'primary.main',
+                                                        color: 'white',
+                                                        cursor: 'pointer',
+                                                        gap: 0.5,
+                                                        px: 1,
+                                                        fontSize: '0.7rem',
+                                                        fontWeight: 600,
+                                                    }}
+                                                >
+                                                    <EventAvailableIcon sx={{ fontSize: 18 }} />
+                                                    {t('races.addToCalendar', 'Calendar')}
+                                                </Box>
+                                            )}
+                                        </Box>
+                                    }
+                                    revealWidth={120}
+                                >
+                                <Card
                                     sx={{
                                         transition: 'transform 0.15s, box-shadow 0.15s',
                                         '&:hover': {
@@ -849,6 +976,7 @@ export default function RacesPage({ mode, onToggleMode, showQuote = false }: Rac
                                         </CardContent>
                                     </CardActionArea>
                                 </Card>
+                                </SwipeableCard>
                             ))}
                         </Stack>
                         </>
@@ -862,6 +990,39 @@ export default function RacesPage({ mode, onToggleMode, showQuote = false }: Rac
                         <EventMapView events={filtered} />
                     </Suspense>
                 )}
+
+                {/* Swipe-right share dialogs */}
+                {(() => {
+                    const ev = shareEventId ? [...justRaced, ...upcoming].find(e => e.id === shareEventId) : null;
+                    if (!ev) return null;
+                    const isFinished = justRaced.some(e => e.id === shareEventId);
+                    const firstDistance = ev.distances?.[0]?.label ?? null;
+                    if (isFinished) {
+                        return (
+                            <RaceFinishCard
+                                open
+                                onClose={() => setShareEventId(null)}
+                                eventName={ev.name}
+                                raceName={ev.name}
+                                distanceLabel={firstDistance}
+                                date={ev.displayDate ?? ev.nextEditionDate}
+                                activityType={ev.activityType}
+                            />
+                        );
+                    }
+                    return (
+                        <RaceShareCard
+                            open
+                            onClose={() => setShareEventId(null)}
+                            eventName={ev.name}
+                            raceName={ev.name}
+                            distanceLabel={firstDistance}
+                            date={ev.displayDate ?? ev.nextEditionDate}
+                            daysUntil={ev.daysUntil}
+                            activityType={ev.activityType}
+                        />
+                    );
+                })()}
             </Container>
         </Layout>
     );


### PR DESCRIPTION
Pull-to-refresh — drag down from top to reload events
Swipe-left — Register + Add to Calendar actions
Swipe-right — "I'm racing!" or "I finished!" share card