### PR TITLE
Update trail details page with redesigned linked races section

### DIFF
--- a/backend/Application/Trails/Queries/GetTrailBySlug/GetTrailBySlugQuery.cs
+++ b/backend/Application/Trails/Queries/GetTrailBySlug/GetTrailBySlugQuery.cs
@@ -65,7 +65,10 @@ public class GetTrailBySlugQueryHandler : IRequestHandler<GetTrailBySlugQuery, T
                     r.EventEdition.Event.Slug,
                     r.Name,
                     r.DistanceLabel,
-                    daysUntil);
+                    daysUntil,
+                    r.StartTime.HasValue ? r.StartTime.Value.ToString("HH:mm") : null,
+                    r.TicketStatus.ToString(),
+                    r.ItraPoints);
             })
             .ToList();
 

--- a/backend/Application/Trails/Queries/GetTrails/GetTrailsQuery.cs
+++ b/backend/Application/Trails/Queries/GetTrails/GetTrailsQuery.cs
@@ -22,7 +22,10 @@ public record LinkedRaceDto(
     string EventSlug,
     string RaceName,
     string? DistanceLabel,
-    int? DaysUntil
+    int? DaysUntil,
+    string? StartTime,
+    string? TicketStatus,
+    int? ItraPoints
 );
 
 public record TrailDto(

--- a/frontend/hooks/useTrails.ts
+++ b/frontend/hooks/useTrails.ts
@@ -20,6 +20,9 @@ export interface LinkedRace {
     raceName: string;
     distanceLabel: string | null;
     daysUntil: number | null;
+    startTime: string | null;
+    ticketStatus: string | null;
+    itraPoints: number | null;
 }
 
 export interface Trail {

--- a/frontend/i18n/en.json
+++ b/frontend/i18n/en.json
@@ -140,8 +140,7 @@
         "loadingMap": "Loading Map...",
         "noGpsData": "No GPS data available for this trail.",
         "wereYouLookingFor": "Were you looking for one of these?",
-        "partOfRace": "Part of {{competition}}",
-        "partOfRaceDistances": "Part of {{competition}} ({{count}} distances)",
+        "racesOnTrail": "Races on this trail",
         "video360": "360° Video",
         "role": {
             "Start": "Start",
@@ -853,6 +852,12 @@
         "backToRaces": "Back to races",
         "wereYouLookingFor": "Were you looking for one of these?",
         "viewTrail": "View trail",
+        "ticketStatus": {
+            "AlmostSoldOut": "Almost sold out",
+            "SoldOut": "Sold out",
+            "Closed": "Registration closed",
+            "Free": "Free entry"
+        },
         "cutoffHours_one": "{{count}} hour cutoff",
         "cutoffHours_other": "{{count}} hours cutoff",
         "cutoffHours": "{{count}}h cutoff",

--- a/frontend/i18n/is.json
+++ b/frontend/i18n/is.json
@@ -140,8 +140,7 @@
         "loadingMap": "Hleð korti...",
         "noGpsData": "Engin GPS gögn tiltæk fyrir þessa leið.",
         "wereYouLookingFor": "Varstu kannski að leita að einni af þessum?",
-        "partOfRace": "Hluti af keppni: {{competition}}",
-        "partOfRaceDistances": "Hluti af keppni: {{competition}} ({{count}} vegalengdir)",
+        "racesOnTrail": "Keppnishlaup á þessari leið",
         "video360": "360° Myndband",
         "role": {
             "Start": "Upphaf",
@@ -853,6 +852,12 @@
         "backToRaces": "Til baka í keppni",
         "wereYouLookingFor": "Varstu að leita að einhverju af þessum?",
         "viewTrail": "Skoða leið",
+        "ticketStatus": {
+            "AlmostSoldOut": "Fáar pláss eftir",
+            "SoldOut": "Uppselt",
+            "Closed": "Skráning lokið",
+            "Free": "Ókeypis"
+        },
         "cutoffHours_one": "{{count}} klukkustund hámark",
         "cutoffHours_other": "{{count}} klukkustundir hámark",
         "cutoffHours": "{{count}}klst hámark",

--- a/frontend/pages/TrailDetailsPage.tsx
+++ b/frontend/pages/TrailDetailsPage.tsx
@@ -620,68 +620,6 @@ export default function TrailDetailsPage({ mode, onToggleMode }: TrailDetailsPag
                         )}
                     </Stack>
 
-                    {/* Linked races banner — grouped by competition */}
-                    {trail.linkedRaces && trail.linkedRaces.length > 0 && isEnabled('races_page') && (() => {
-                        // Group races by competition slug
-                        const byCompetition = trail.linkedRaces!.reduce<Record<string, typeof trail.linkedRaces[0][]>>(
-                            (acc, race) => {
-                                (acc[race.eventSlug] ??= []).push(race);
-                                return acc;
-                            },
-                            {}
-                        );
-                        return (
-                            <Box sx={{ mb: 2 }}>
-                                {Object.values(byCompetition).map((races) => {
-                                    const rep = races[0];
-                                    const label = races.length > 1
-                                        ? t('trail.partOfRaceDistances', { competition: rep.eventName, count: races.length })
-                                        : t('trail.partOfRace', { competition: rep.eventName });
-                                    // Use the nearest upcoming occurrence across all linked races
-                                    const daysUntil = races.reduce<number | null>((min, r) => {
-                                        if (r.daysUntil == null || r.daysUntil < 0) return min;
-                                        return min == null ? r.daysUntil : Math.min(min, r.daysUntil);
-                                    }, null);
-                                    return (
-                                        <Paper
-                                            key={rep.eventSlug}
-                                            component={RouterLink}
-                                            to={`/events/${rep.eventSlug}`}
-                                            elevation={0}
-                                            sx={{
-                                                display: 'flex',
-                                                alignItems: 'center',
-                                                gap: 1,
-                                                px: 2,
-                                                py: 1,
-                                                mb: 0.5,
-                                                borderRadius: 2,
-                                                bgcolor: 'action.hover',
-                                                textDecoration: 'none',
-                                                color: 'inherit',
-                                                transition: 'background-color 0.2s',
-                                                '&:hover': { bgcolor: 'action.selected' },
-                                            }}
-                                        >
-                                            <Typography variant="body2" sx={{ flexGrow: 1 }}>
-                                                🏆 {label}
-                                            </Typography>
-                                            {daysUntil != null && (
-                                                <Chip
-                                                    label={daysUntil === 0
-                                                        ? t('races.today')
-                                                        : t('races.daysUntil', { count: daysUntil })}
-                                                    size="small"
-                                                    color="success"
-                                                    sx={{ fontSize: '0.7rem', height: 22 }}
-                                                />
-                                            )}
-                                        </Paper>
-                                    );
-                                })}
-                            </Box>
-                        );
-                    })()}
 
                     {trail.description && (
                         <Typography variant="body1" color="text.secondary" sx={{ mb: 2, lineHeight: 1.7, whiteSpace: 'pre-line' }}>
@@ -948,6 +886,99 @@ export default function TrailDetailsPage({ mode, onToggleMode }: TrailDetailsPag
                     {toastMessage}
                 </Alert>
             </Snackbar>
+
+            {(() => {
+                const visibleRaces = (trail.linkedRaces ?? []).filter(
+                    r => r.daysUntil == null || r.daysUntil >= -30
+                );
+                if (!visibleRaces.length) return null;
+
+                const byEvent = visibleRaces.reduce<Record<string, typeof visibleRaces>>((acc, r) => {
+                    (acc[r.eventSlug] ??= []).push(r);
+                    return acc;
+                }, {});
+
+                return (
+                    <Box mt={4} mb={3}>
+                        <Typography variant="h5" component="h2" fontWeight="bold" mb={1.5}>
+                            {t('trail.racesOnTrail')}
+                        </Typography>
+                        <Grid container spacing={1.5}>
+                            {Object.values(byEvent).flatMap(races =>
+                                races.map(race => {
+                                    const past = race.daysUntil != null && race.daysUntil < 0;
+                                    return (
+                                        <Grid item xs={12} sm={6} md={4} key={`${race.eventSlug}-${race.raceName}`}>
+                                            <Paper
+                                                component={RouterLink}
+                                                to={`/events/${race.eventSlug}`}
+                                                elevation={0}
+                                                sx={{
+                                                    display: 'flex',
+                                                    flexDirection: 'column',
+                                                    gap: 0.5,
+                                                    p: 2,
+                                                    borderRadius: 2,
+                                                    bgcolor: 'action.hover',
+                                                    textDecoration: 'none',
+                                                    color: 'inherit',
+                                                    height: '100%',
+                                                    transition: 'background-color 0.2s',
+                                                    '&:hover': { bgcolor: 'action.selected' },
+                                                }}
+                                            >
+                                                <Typography variant="caption" color="text.secondary" noWrap>
+                                                    {race.eventName}
+                                                </Typography>
+                                                <Typography variant="body2" fontWeight={600} noWrap>
+                                                    {race.raceName}
+                                                </Typography>
+                                                {race.startTime && (
+                                                    <Typography variant="caption" color="text.secondary">
+                                                        🕐 {race.startTime}
+                                                    </Typography>
+                                                )}
+                                                <Stack direction="row" spacing={0.75} alignItems="center" mt={0.75} flexWrap="wrap" gap={0.5}>
+                                                    {race.distanceLabel && (
+                                                        <Chip label={race.distanceLabel} size="small" variant="outlined" sx={{ fontSize: '0.7rem', height: 22 }} />
+                                                    )}
+                                                    {race.itraPoints != null && (
+                                                        <Chip label={`ITRA ${race.itraPoints}`} size="small" variant="outlined" sx={{ fontSize: '0.7rem', height: 22 }} />
+                                                    )}
+                                                    {race.ticketStatus && race.ticketStatus !== 'Available' && race.ticketStatus !== 'NotStarted' && (
+                                                        <Chip
+                                                            label={t(`races.ticketStatus.${race.ticketStatus}`)}
+                                                            size="small"
+                                                            color={race.ticketStatus === 'SoldOut' || race.ticketStatus === 'Closed' ? 'error' : race.ticketStatus === 'AlmostSoldOut' ? 'warning' : 'default'}
+                                                            sx={{ fontSize: '0.7rem', height: 22 }}
+                                                        />
+                                                    )}
+                                                    {race.daysUntil != null && (
+                                                        <Chip
+                                                            label={
+                                                                race.daysUntil === 0
+                                                                    ? t('races.today')
+                                                                    : race.daysUntil === 1
+                                                                    ? t('races.tomorrow')
+                                                                    : past
+                                                                    ? t('races.daysAgo_other', { count: Math.abs(race.daysUntil) })
+                                                                    : t('races.daysUntil', { count: race.daysUntil })
+                                                            }
+                                                            size="small"
+                                                            color={past ? 'default' : race.daysUntil <= 7 ? 'warning' : 'success'}
+                                                            sx={{ fontSize: '0.7rem', height: 22 }}
+                                                        />
+                                                    )}
+                                                </Stack>
+                                            </Paper>
+                                        </Grid>
+                                    );
+                                })
+                            )}
+                        </Grid>
+                    </Box>
+                );
+            })()}
 
             {isEnabled('related_trails') && relatedTrails.length > 0 && (
                 <Box mt={4} mb={6}>


### PR DESCRIPTION
- Replace grouped "linked races" banner with a grid-based "races on this trail" section.
- Add support for displaying ticket status, ITRA points, start time, and improved filtering for linked races.
- Update i18n with new labels for ticket statuses in English and Icelandic.
- Refactor backend DTOs and queries to include additional race details.