### PR TITLE
Add climb ratio metric to trail details and cards

### DIFF
--- a/frontend/components/TrailCard.tsx
+++ b/frontend/components/TrailCard.tsx
@@ -401,6 +401,12 @@ export const TrailCard: React.FC<TrailCardProps> = ({ trail, onToggleFavorite, o
                             <TrendingDownIcon sx={{ mr: compact ? 0 : 0.5, fontSize: compact ? 14 : 18, color: 'error.main' }} />
                             <Typography variant="body2" fontSize={compact ? '0.75rem' : undefined}>-{Math.round(trail.elevationLoss)}</Typography>
                         </Box>
+                        {!compact && trail.activityType === 'TrailRunning' && trail.length > 0 && (
+                            <Box display="flex" alignItems="center">
+                                <LandscapeIcon sx={{ mr: 0.5, fontSize: 18 }} />
+                                <Typography variant="body2">{Math.round(trail.elevationGain / (trail.length / 1000))} m/km</Typography>
+                            </Box>
+                        )}
                         {estTime && (
                         <Box display="flex" alignItems="center">
                             <AccessTimeIcon sx={{ mr: compact ? 0 : 0.5, fontSize: compact ? 14 : 18 }} />

--- a/frontend/i18n/en.json
+++ b/frontend/i18n/en.json
@@ -141,6 +141,7 @@
         "noGpsData": "No GPS data available for this trail.",
         "wereYouLookingFor": "Were you looking for one of these?",
         "racesOnTrail": "Races on this trail",
+        "climbRatio": "Climb ratio",
         "video360": "360° Video",
         "role": {
             "Start": "Start",

--- a/frontend/i18n/is.json
+++ b/frontend/i18n/is.json
@@ -141,6 +141,7 @@
         "noGpsData": "Engin GPS gögn tiltæk fyrir þessa leið.",
         "wereYouLookingFor": "Varstu kannski að leita að einni af þessum?",
         "racesOnTrail": "Keppnishlaup á þessari leið",
+        "climbRatio": "Klifurhlutfall",
         "video360": "360° Myndband",
         "role": {
             "Start": "Upphaf",

--- a/frontend/pages/TrailDetailsPage.tsx
+++ b/frontend/pages/TrailDetailsPage.tsx
@@ -651,14 +651,25 @@ export default function TrailDetailsPage({ mode, onToggleMode }: TrailDetailsPag
                                 <Typography variant="subtitle2" sx={{ fontWeight: 'bold' }}>-{Math.round(trail.elevationLoss)}m</Typography>
                             </Stack>
                         </Grid>
-                        <Grid item xs={6} sm>
+                        {trail.activityType === 'TrailRunning' && trail.length > 0 && (
+                            <Grid item xs={4} sm>
+                                <Stack alignItems="center" spacing={0.5}>
+                                    <LandscapeIcon color="action" fontSize="small" />
+                                    <Typography variant="caption" color="text.secondary" sx={{ display: { xs: 'none', sm: 'block' } }}>{t('trail.climbRatio')}</Typography>
+                                    <Typography variant="subtitle2" sx={{ fontWeight: 'bold' }}>
+                                        {Math.round(trail.elevationGain / (trail.length / 1000))} m/km
+                                    </Typography>
+                                </Stack>
+                            </Grid>
+                        )}
+                        <Grid item xs={4} sm>
                             <Stack alignItems="center" spacing={0.5}>
                                 {getTrailTypeIcon(trail.trailType)}
                                 <Typography variant="caption" color="text.secondary" sx={{ display: { xs: 'none', sm: 'block' } }}>{t('trail.type')}</Typography>
                                 <Typography variant="subtitle2" sx={{ fontWeight: 'bold', textAlign: 'center' }}>{getTrailTypeLabel(trail.trailType, t)}</Typography>
                             </Stack>
                         </Grid>
-                        <Grid item xs={6} sm>
+                        <Grid item xs={4} sm>
                             {isEnabled('pace_info') && estTime && <PaceInfo activityType={trail.activityType} formattedDuration={estTime} />}
                         </Grid>
                     </Grid>


### PR DESCRIPTION
- Display climb ratio (elevation gain per km) for TrailRunning activity types in TrailDetailsPage and TrailCard components.
- Include corresponding i18n translations for English and Icelandic.